### PR TITLE
TODO WAOW

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -402,3 +402,4 @@ FodyWeavers.xsd
 
 # Ignore csproj and a temporary note so that the output path wnot be push to remote repo automatically
 RavenM/RavenM.csproj
+note

--- a/RavenM/Commands/CommandManager.cs
+++ b/RavenM/Commands/CommandManager.cs
@@ -134,6 +134,7 @@ namespace RavenM.Commands
         }
         public bool HasRequiredArgs(Command cmd, string[] command)
         {
+            // TODO: is args check needed? as there will be a bug when there are optional args, i think try and catch block is enough
             return true;
             // Shift Array by one to the right because command[0] would be the initCommand  - Chryses
             string[] args = new string[command.Length - 1];

--- a/RavenM/DiscordIntegration.cs
+++ b/RavenM/DiscordIntegration.cs
@@ -141,9 +141,7 @@ namespace RavenM
 
             if (_isInGame && !_isInLobby)
             {
-                var dropdown = InstantActionMaps.instance.gameModeDropdown;
-                _gameMode = dropdown.options[dropdown.value].text;
-                UpdateActivity(Discord, Activities.InSinglePlayerGame, true ,_gameMode);
+                UpdateActivity(Discord, Activities.InSinglePlayerGame, true,LobbySystem.instance.currentGameMode.ToString());
             }
             else if (_isInLobby)
             {
@@ -152,9 +150,7 @@ namespace RavenM
 
                 if (!_isInGame) // Waiting in Lobby
                 {
-                    var dropdown = InstantActionMaps.instance.gameModeDropdown;
-                    _gameMode = dropdown.options[dropdown.value].text;
-                    UpdateActivity(Discord, Activities.InLobby, false ,_gameMode, currentLobbyMembers, currentLobbyMemberCap, LobbySystem.instance.ActualLobbyID.ToString());
+                    UpdateActivity(Discord, Activities.InLobby, false , LobbySystem.instance.currentGameMode.ToString(), currentLobbyMembers, currentLobbyMemberCap, LobbySystem.instance.ActualLobbyID.ToString());
                 }
                 else // Playing in a Lobby
                 {

--- a/RavenM/LobbySystem.cs
+++ b/RavenM/LobbySystem.cs
@@ -1156,7 +1156,7 @@ namespace RavenM
                             hasRequestLobbyListBefore = true;
                     }
 
-                    GUILayout.Label($"RavenM v{MyPluginInfo.PLUGIN_VERSION} patch 4\nClient Id: {Plugin.BuildGUID}");
+                    GUILayout.Label($"RavenM v{MyPluginInfo.PLUGIN_VERSION}\nClient Id: {Plugin.BuildGUID}");
                     if (GUILayout.Button("Project webpage"))
                         Application.OpenURL("https://ravenfieldcommunity.github.io/docs/en/Projects/ravenm.html");
                 }
@@ -1515,7 +1515,7 @@ namespace RavenM
                             foreach (Actor actor in ActorManager.instance.actors)
                             {
                                 if (actor.name.ToLower() == name.ToLower())
-                                    readyColor = actor.dead ? "#BEBEBE" : "00FF00";
+                                    readyColor = actor.dead ? "#484848" : "00FF00";
                             }
                     else
                         readyColor = (GameManager.IsInMainMenu() ? SteamMatchmaking.GetLobbyMemberData(ActualLobbyID, memberId, "loaded") == "yes"

--- a/RavenM/Plugin.cs
+++ b/RavenM/Plugin.cs
@@ -75,7 +75,7 @@ namespace RavenM
             }
         }
 
-        public static readonly int EXPECTED_BUILD_NUMBER = 31;
+        public static readonly int EXPECTED_BUILD_NUMBER = 32;
 
         private ConfigEntry<bool> configRavenMDevMod;
         private bool showBuildGUID;

--- a/RavenM/Plugin.cs
+++ b/RavenM/Plugin.cs
@@ -66,11 +66,11 @@ namespace RavenM
             {
                 if (!changeGUID)
                 {
-                    return $"INDEV-EA{(currentGameBuildNumber == 0 ? 0 : currentGameBuildNumber)}-{MyPluginInfo.PLUGIN_VERSION.Replace(".","-")}-{Assembly.GetExecutingAssembly().ManifestModule.ModuleVersionId.ToString().Split('-').Last()}";
+                    return $"INDEV-EA{(GameManager.instance == null ? 0 : GameManager.instance.buildNumber)}-{MyPluginInfo.PLUGIN_VERSION.Replace(".","-")}-{Assembly.GetExecutingAssembly().ManifestModule.ModuleVersionId.ToString().Split('-').Last()}";
                 }
                 else
                 {
-                    return $"TESTMODE-EA{(currentGameBuildNumber == 0 ? 0 : currentGameBuildNumber)}-{MyPluginInfo.PLUGIN_VERSION.Replace(".","-")}-89a27d9e2fcb";
+                    return $"TESTMODE-EA{(GameManager.instance == null ? 0 : GameManager.instance.buildNumber)}-{MyPluginInfo.PLUGIN_VERSION.Replace(".","-")}-89a27d9e2fcb";
                 }
             }
         }
@@ -85,7 +85,7 @@ namespace RavenM
         public static float chatYOffset = 370f;
         public static float chatXOffset = 10f;
         public static int chatFontSize = 0;
-        public static bool allowVersionDiff = false;
+        public static bool allowClientDifference = false;
         public static bool changeChatFontSize = false;  //If need to change the font size
         
         private ConfigEntry<bool> configRavenMAddToBuiltInMutators;
@@ -146,10 +146,10 @@ namespace RavenM
                 "Chat Font Size",
                 0,
                 "Change the font size of chat field(0 is disable).").Value;
-            allowVersionDiff = Config.Bind("General.Toggles",
-                "Allow clients with different plugin version",
+            allowClientDifference = Config.Bind("General.Toggles",
+                "Allow client difference",
                 false,
-                "Allow host and players use plugins with different version.").Value;
+                "Allow host and players use plugins or game with different version.").Value;
             if (chatFontSize != 0)
                 changeChatFontSize = true;
             changeGUID = configRavenMDevMod.Value;
@@ -161,7 +161,7 @@ namespace RavenM
             }
             else
             {
-                if (customBuildInMutators != "NOT_REAL" && customBuildInMutators != "")
+                if (customBuildInMutators != "")
                 {
                     Logger.LogError($"Directory {customBuildInMutators} could not be found.");
                 }
@@ -226,9 +226,6 @@ namespace RavenM
                 discordObject.AddComponent<DiscordIntegration>();
                 DontDestroyOnLoad(discordObject);
             }
-            else if (!HasGotGameBuildNumber)
-                if ( GameManager.instance != null)
-                    currentGameBuildNumber = GameManager.instance.buildNumber;
             else if (!JoinedLobbyFromArgument && Arguments.ContainsKey("-ravenm-lobby"))
             {
                 JoinLobbyFromArgument();

--- a/RavenM/RavenM.csproj
+++ b/RavenM/RavenM.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="BepInEx.Core" Version="5.4.21" />
     <PackageReference Include="BepInEx.PluginInfoProps" Version="2.1.0" />
     <PackageReference Include="Ravenfield.GameLibs" Version="0.32.1" IncludeAssets="compile" />
-    <PackageReference Include="Ravenfield.ThirdpartyLibs" Version="0.32.0" IncludeAssets="compile" />
+    <PackageReference Include="Ravenfield.ThirdpartyLibs" Version="0.32.1" IncludeAssets="compile" />
     <PackageReference Include="UnityEngine.Modules" Version="2020.3.48" IncludeAssets="compile" />
   </ItemGroup>
   

--- a/RavenM/RavenM.csproj
+++ b/RavenM/RavenM.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net46</TargetFramework>
     <AssemblyName>RavenM</AssemblyName>
     <Description>A Ravenfield multiplayer mod.</Description>
-    <Version>0.7</Version>
+    <Version>0.9</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <BaseIntermediateOutputPath>obj\</BaseIntermediateOutputPath>
@@ -30,7 +30,7 @@
     <PackageReference Include="BepInEx.Analyzers" Version="1.0.8" PrivateAssets="all" />
     <PackageReference Include="BepInEx.Core" Version="5.4.21" />
     <PackageReference Include="BepInEx.PluginInfoProps" Version="2.1.0" />
-    <PackageReference Include="Ravenfield.GameLibs" Version="0.32.0" IncludeAssets="compile" />
+    <PackageReference Include="Ravenfield.GameLibs" Version="0.32.1" IncludeAssets="compile" />
     <PackageReference Include="Ravenfield.ThirdpartyLibs" Version="0.32.0" IncludeAssets="compile" />
     <PackageReference Include="UnityEngine.Modules" Version="2020.3.48" IncludeAssets="compile" />
   </ItemGroup>

--- a/RavenM/rspatch/RSPatch.cs
+++ b/RavenM/rspatch/RSPatch.cs
@@ -126,7 +126,7 @@ namespace RavenM.RSPatch
         {
             if (Plugin.addToBuiltInMutators)
             {
-                foreach (MutatorEntry entry in __instance.loadedMutators)
+                foreach (MutatorEntryData entry in __instance.loadedMutators)
                 {
                     if (!__instance.builtInMutators.Contains(entry))
                     {

--- a/RavenM/rspatch/Wrapper/WLobby.cs
+++ b/RavenM/rspatch/Wrapper/WLobby.cs
@@ -168,12 +168,21 @@ namespace RavenM.RSPatch.Wrapper
             }
             return output;
         }
+
+        // TODO: Test if it is decuplicated
         public static void AddVehiclesToNetworkPrefab()
         {
-            foreach (VehicleSpawner.VehicleSpawnType vehicleType in VehicleSpawner.ALL_VEHICLE_TYPES) {
-            
-                GameObject vehiclePrefab = VehicleSpawner.GetPrefab(0, vehicleType);
-                networkGameObjects.Add(vehiclePrefab.GetHashCode().ToString(), vehiclePrefab);
+            for (int i = 0; i < 2; i++)
+            {
+                var teamInfo = GameManager.instance.gameInfo.team[i];
+                foreach (var slotReal in teamInfo.vehicleSlot)
+                {
+                    foreach (var a in slotReal.Value.AllPrefabs())
+                    {
+                        var hash = a.GetHashCode().ToString();
+                        if (!networkGameObjects.ContainsKey(hash)) networkGameObjects.Add(hash, a);
+                    }
+                }
             }
             setupVehicles = true;
         }


### PR DESCRIPTION
OK HERE TODO (`V` is finished, `?` is havent tested or not sure work on unexpection, none is havent solved, `no` is won't fix):

- (V) feat: inspector team addition
  works well, id really care whether there will be such `enterMsg` for it
  wait I need and name tags support for it
- (V) fix: C4 projectile sync while hot join
  now? the model should be instanced after joining i think
- (V) fix: arachute sync
  move to flag
- (V) fix: spook mode stopped after host death
  i hate il transpiler(in fact there isn't)
- (V) fix: rich text and `\` filter test (finally no rich text filter)
- (V) fix: join message has bug bks inspector check??
  same lobby with multiple matches just
- (V) fix: sometimes players cant spawn correctly 
  bks wrong spawnpoints config or map sync especially ?map editor?
  now first reason in EA32 build is bks wrong map sync
-  (V)fix: config sync on ea32(linked with prev one)
   hotjoin and sent to island; team color; empty map bks the menu class hasnt clean the null field yet
   ok because of map double check and wrong game mode
- (V) fix: chat backend
  inspector cannot be iden well
- (?) fix: tp and ban command
  fxxk, only tp doesn't work
- (no) feat: local ip connect
- feat: match records
- (V) feat: del options patch
- fix: bug on `OnLobbyEnter()`
  before setting  the state to true, perhaps, i hate network debug because I can't reshow it
- feat: join lobby before `GotoMenu`
- fix: scoreboard sync
  hotjoin or normal scene
- (?) feat: ui and chat remake
  chat field delay hidden, announcement board, menu fold for more option, little main button waow, marker and voice nametags
  voice count not works, name tags for spectator doesn't do yet
- (?)fix: sometimes other players can't spawn correctly in spook mode
  this is related to network now
- (?) feat: network checker
- fix: mission story bugs
  of course trigger system
- (V) feat: update announcement from github
- (V) docs: img
- (V) feat: client id sort items
- fix: ime bug
  i wonder why team chat cause interal unity bug in ms chinese ime
- (V) feat&fix: lobby chat tag, mappicker when should load item
- (?) fix: network stability
  like cannot spawn in map with empty capture flags sync, maybe no mods help?
  seems at that time we can't go back menu?
  wonder if it's in that map start patch method, and spook spawn issue has sth to do with it
  ok i guess we need to have a check with steam socket or use ?fake ip?
- feat: lobby conf save for next time
- feat: mod sync strategy about using steam item collections
- (?) feat: friend nickname and tags
- (?) fix: map editor save path conflict 
- feat: new arcade mode 
- (V) feat: less name length in chat field
- feat: move p2p to mirror or remake the connecting backend
- fix: ?friend only 
- style: reorganize the code in lobbysys.update, split the parts


WAOW Full test cil:
```sh
taskkill /f /im ravenfield.exe;
dotnet build ravenm;
copy .\ravenm\bin\Debug\net46\RavenM.dll "D:\Program Files\pip3.7\steamapps\common\Ravenfield\BepInEx\plugins\net46";
copy .\ravenm\bin\Debug\net46\RavenM.pdb "D:\Program Files\pip3.7\steamapps\common\Ravenfield\BepInEx\plugins\net46";
& 'd:\Program Files\pip3.7\steamapps\common\Ravenfield\ravenfield.exe';
copy "D:\Program Files\pip3.7\steamapps\common\Ravenfield\BepInEx\plugins\net46\RavenM.dll" "D:\Program Files\pip3.7\steamapps\common\Ravenfield-EA32_250706\BepInEx\plugins\net46";
copy "D:\Program Files\pip3.7\steamapps\common\Ravenfield\BepInEx\plugins\net46\RavenM.pdb" "D:\Program Files\pip3.7\steamapps\common\Ravenfield-EA32_250706\BepInEx\plugins\net46"; 
& 'd:\Program Files\pip3.7\steamapps\common\Ravenfield-EA32_250706\ravenfield.exe';
Echo;
```